### PR TITLE
[Fix] spotbugs finding via mvn verify

### DIFF
--- a/src/main/java/io/jenkins/plugins/junit/storage/database/DatabaseTestResultStorage.java
+++ b/src/main/java/io/jenkins/plugins/junit/storage/database/DatabaseTestResultStorage.java
@@ -648,7 +648,7 @@ public class DatabaseTestResultStorage extends JunitTestResultStorage {
 
         @Override public void publish(TestResult result, TaskListener listener) throws IOException {
             try {
-                try (Connection connection = connectionSupplier.connection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO caseResults (job, build, suite, package, className, testName, errorDetails, skipped, duration, stdout, stderr, stacktrace) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+                try (PreparedStatement statement = connectionSupplier.connection().prepareStatement("INSERT INTO caseResults (job, build, suite, package, className, testName, errorDetails, skipped, duration, stdout, stderr, stacktrace) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
                     int count = 0;
                     for (SuiteResult suiteResult : result.getSuites()) {
                         for (CaseResult caseResult : suiteResult.getCases()) {


### PR DESCRIPTION
calling mvn clean verify resulted in spotbugs finding RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE. 

Changed line 651 a bit and finding was made unfound.  This PR resolves #100 (for me)