### PR TITLE
Inclusion of timestamp column in the caseresults table schema

### DIFF
--- a/src/main/resources/db/migration/V2020_12_15_1153__timestamp-inclusion.sql
+++ b/src/main/resources/db/migration/V2020_12_15_1153__timestamp-inclusion.sql
@@ -1,0 +1,2 @@
+ALTER TABLE caseresults
+    ADD COLUMN timestamp timestamp NOT NULL DEFAULT NOW()


### PR DESCRIPTION
@timja
It would be quite helpful, if we could include timestamp column in Caseresults table, as this could be leveraged, in the cleanup of entries which are older than a particular threshold.
Otherwise there would be table keep on populating database, without ant cleanup.