### PR TITLE
Update baseline to 2.289 (required for tests to pass on Mac M1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <revision>0.6</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.277.1</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>
@@ -26,7 +26,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.277.x</artifactId>
+                <artifactId>bom-2.289.x</artifactId>
                 <version>919.v3c802a29576e</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
Need the JNA update from https://github.com/jenkinsci/jenkins/pull/5273 for tests to pass on Mac M1