### PR TITLE
Handle deadlock when too many connections are open

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>database</artifactId>
-            <version>1.9</version>
+            <version>117.va2009e38b882</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>


### PR DESCRIPTION
Close connections explicitly rather than relying on something else doing it

Deadlock is the same as in https://issues.apache.org/jira/browse/DBCP-513

Can easily reproduce deadlock by starting a lot of builds at the same time without many executors.
Cannot reproduce after