### PR TITLE
Instrument jdbc datasource to see SQL statement spans in the traces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <opentelemetry-alpha.version>1.39.0-alpha</opentelemetry-alpha.version>
         <opentelemetry-instrumentation-alpha.version>2.4.0-alpha</opentelemetry-instrumentation-alpha.version>
-        <opentelemetry-contrib.version>1.36.0-alpha</opentelemetry-contrib.version>
         <opentelemetry-semconv>1.25.0-alpha</opentelemetry-semconv>
     </properties>
     <name>Junit SQL Storage Plugin</name>
@@ -81,10 +80,9 @@
         </dependency>
         <!-- Begin OpenTelemetry dependencies-->
         <!--
-        TODO extract OpenTelemetry APIs in a library plugin
-        similar to the jackson2-api-plugin that all plugins
-        that use OTel APIs, including the opentelemetry-plugin,
-        would depend on
+        Waiting for the introduction of the io.jenkins.plugins:opentelemetry-api-plugin
+        https://github.com/jenkins-infra/repository-permissions-updater/issues/3973
+        we pull in the OpenTelemetry dependencies directly.
         -->
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,8 @@
         <jenkins.baseline>2.440</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <useBeta>true</useBeta>
-        <opentelemetry.version>1.39.0</opentelemetry.version>
-        <opentelemetry-alpha.version>1.39.0-alpha</opentelemetry-alpha.version>
-        <opentelemetry-instrumentation-alpha.version>2.4.0-alpha</opentelemetry-instrumentation-alpha.version>
-        <opentelemetry-semconv>1.25.0-alpha</opentelemetry-semconv>
+        <jenkins-plugin-opentelemetry.version>3.1215.vc9db_a_0b_34c2a_</jenkins-plugin-opentelemetry.version>
+        <opentelemetry-instrumentation.version>2.5.0</opentelemetry-instrumentation.version>
     </properties>
     <name>Junit SQL Storage Plugin</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
@@ -34,23 +32,9 @@
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-bom</artifactId>
-                <version>${opentelemetry.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-bom-alpha</artifactId>
-                <version>${opentelemetry-alpha.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-                <version>${opentelemetry-instrumentation-alpha.version}</version>
+                <version>${opentelemetry-instrumentation.version}-alpha</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -79,42 +63,22 @@
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>caffeine-api</artifactId>
         </dependency>
-        <!-- Begin OpenTelemetry dependencies-->
-        <!--
-        Waiting for the introduction of the io.jenkins.plugins:opentelemetry-api-plugin
-        https://github.com/jenkins-infra/repository-permissions-updater/issues/3973
-        we pull in the OpenTelemetry dependencies directly.
-        -->
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry.semconv</groupId>
-            <artifactId>opentelemetry-semconv</artifactId>
-            <version>${opentelemetry-semconv}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry.semconv</groupId>
-            <artifactId>opentelemetry-semconv-incubating</artifactId>
-            <version>${opentelemetry-semconv}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry.instrumentation</groupId>
-            <artifactId>opentelemetry-jdbc</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>opentelemetry</artifactId>
-            <version>3.1215.vc9db_a_0b_34c2a_</version>
+            <version>${jenkins-plugin-opentelemetry.version}</version>
             <exclusions>
                 <exclusion>
+                    <!-- 2.18.0 (managed) vs 2.28.0 -->
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- End OpenTelemetry dependencies-->
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-jdbc</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,11 @@
         <gitHubRepo>jenkinsci/junit-sql-storage-plugin</gitHubRepo>
         <jenkins.version>2.414.3</jenkins.version>
         <useBeta>true</useBeta>
+        <opentelemetry.version>1.39.0</opentelemetry.version>
+        <opentelemetry-alpha.version>1.39.0-alpha</opentelemetry-alpha.version>
+        <opentelemetry-instrumentation-alpha.version>2.4.0-alpha</opentelemetry-instrumentation-alpha.version>
+        <opentelemetry-contrib.version>1.36.0-alpha</opentelemetry-contrib.version>
+        <opentelemetry-semconv>1.25.0-alpha</opentelemetry-semconv>
     </properties>
     <name>Junit SQL Storage Plugin</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
@@ -28,6 +33,27 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <version>${opentelemetry-alpha.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+                <version>${opentelemetry-instrumentation-alpha.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -39,6 +65,7 @@
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>flyway-api</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>database-postgresql</artifactId>
@@ -52,6 +79,31 @@
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>caffeine-api</artifactId>
         </dependency>
+        <!-- Begin OpenTelemetry dependencies-->
+        <!--
+        TODO extract OpenTelemetry APIs in a library plugin
+        similar to the jackson2-api-plugin that all plugins
+        that use OTel APIs, including the opentelemetry-plugin,
+        would depend on
+        -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>${opentelemetry-semconv}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv-incubating</artifactId>
+            <version>${opentelemetry-semconv}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-jdbc</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>opentelemetry</artifactId>
@@ -63,6 +115,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- End OpenTelemetry dependencies-->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>

--- a/src/main/java/io/jenkins/plugins/junit/storage/database/DatabaseTestResultStorage.java
+++ b/src/main/java/io/jenkins/plugins/junit/storage/database/DatabaseTestResultStorage.java
@@ -23,12 +23,12 @@ import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
 import io.jenkins.plugins.junit.storage.JunitTestResultStorageDescriptor;
 import io.jenkins.plugins.junit.storage.TestResultImpl;
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.jdbc.datasource.JdbcTelemetry;
 import io.opentelemetry.instrumentation.jdbc.datasource.OpenTelemetryDataSource;
+import io.opentelemetry.semconv.incubating.DbIncubatingAttributes;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
@@ -921,9 +921,7 @@ public class DatabaseTestResultStorage extends JunitTestResultStorage {
     }
 
     private static void addSqlAttribute(Span span, String sql) {
-        // `db.query.text` not yet in `DbIncubatingAttributes` of opentelemetry-semconv-incubating:1.25 so
-        // manually declare it
-        span.setAttribute(AttributeKey.stringKey("db.query.text"), sql);
+        span.setAttribute(DbIncubatingAttributes.DB_STATEMENT, sql);
     }
 
     private static void addPackageAttribute(Span span, String packageName) {


### PR DESCRIPTION
Instrument the JDBC data source with OpenTelemetry to see SQL statement spans in the traces.

### Testing done

Integration test done:

<img width="2558" alt="image" src="https://github.com/jenkinsci/junit-sql-storage-plugin/assets/459691/f8415662-689f-41dc-a3c9-58bfc31d311e">

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
